### PR TITLE
[TASK] improve download command

### DIFF
--- a/src/Command/DownloadCommand.php
+++ b/src/Command/DownloadCommand.php
@@ -2,12 +2,14 @@
 
 namespace CMuench\PHPStormDownloader\Command;
 
-use Goutte\Client;
+use CMuench\PHPStormDownloader\Repository\Eap;
+use CMuench\PHPStormDownloader\Repository\HttpSource;
+use CMuench\PHPStormDownloader\Repository\Stable;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Process\Process;
 
 class DownloadCommand extends Command
@@ -18,54 +20,94 @@ class DownloadCommand extends Command
             ->setName('download')
             ->setDescription('Download PhpStorm to target folder and create a Symlink "PhpStorm" to latest version.')
             ->addArgument('target-folder', InputArgument::OPTIONAL, 'Target Folder for Installation', $_SERVER['HOME'] . '/opt')
+            ->addOption('download', null, InputOption::VALUE_NONE, 'Download even if target version already exists')
+            ->addOption('stable', null, InputOption::VALUE_NONE, 'Use stable release, not EAP')
         ;
     }
 
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int|null|void
+     */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $url = 'http://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Early+Access+Program';
         $targetFolder = $input->getArgument('target-folder');
         if (!is_dir($targetFolder)) {
             throw new \LogicException('Folder ' . $targetFolder . ' does not exist.');
         }
 
-        try {
-            $client = new Client();
-            $output->write('<comment>Request PhpStorm EAP: </comment>');
-            $crawler = $client->request('GET', $url);
-            $output->writeln('<info>OK</info>');
-            $crawler->filter('a.external-link')
-                ->reduce(function (Crawler $node, $i) {
-                    return strstr($node->text(), '.tar.gz');
-                })
-                ->each(function ($node) use ($targetFolder, $output) {
-                    $downloadUrl = $node->attr('href');
-                    if (preg_match('/PhpStorm-EAP-(\d+\.\d+)\.tar\.gz/i', $node->text(), $matches)) {
-                        $phpStormVersion = $matches[1];
-                        $output->writeln('<comment>Found EAP Version   : </comment><info>' . $phpStormVersion . '</info>');
+        $forceDownload = (bool) $input->getOption('download');
 
-                        $output->write('<comment>Download            : </comment>');
-                        $downloadProcess = new Process("wget $downloadUrl -O phpstorm.tar.gz");
-                        $downloadProcess->setTimeout(3600);
-                        $downloadProcess->run();
+        $stable = (bool) $input->getOption('stable');
 
-                        $output->writeln('<info>OK</info>');
-                        if (!$downloadProcess->isSuccessful()) {
-                            throw new \RuntimeException($downloadProcess->getErrorOutput());
-                        }
+        $repo = $stable ? new Stable() : new Eap();
 
-                        $extractedFolder = 'PhpStorm-' . $phpStormVersion;
-                        $output->write('<comment>Extract             : </comment>');
-                        $extractProcess = new Process("tar xfz phpstorm.tar.gz; rm phpstorm.tar.gz; mv $extractedFolder $targetFolder; cd $targetFolder; rm PhpStorm; ln -s $extractedFolder PhpStorm");
-                        $extractProcess->run();
-                        $output->writeln('<info>OK</info>');
-                        if (!$extractProcess->isSuccessful()) {
-                            throw new \RuntimeException($extractProcess->getErrorOutput());
-                        }
-                    }
-                });
-        } catch (\Exception $e) {
-            $output->writeln('<error>' . $e->getMessage() . '</error>');
+        $repo->initialize($output);
+
+        foreach ($repo->getSources() as $source) {
+            $this->install($output, $targetFolder, $forceDownload, $source);
+            break;
         }
+    }
+
+    private function install(OutputInterface $output, $targetFolder, $forceDownload, HttpSource $source)
+    {
+        $version = $source->getVersion();
+
+        $extractedFolder = 'PhpStorm-' . $version;
+
+        if (is_dir($targetFolder . '/' . $extractedFolder) && false === $forceDownload) {
+            $output->writeln(
+                sprintf(
+                    '<comment>Phpstorm <info>%s</info> already exists, skipping download..</comment>', $version
+                )
+            );
+        } else {
+            $output->write(
+                sprintf(
+                    '<comment>Download %s </comment><info>%s</info><comment>...</comment>', $source->getName(), $version
+                )
+            );
+
+            $downloadProcess = new Process(sprintf("wget %s -O phpstorm.tar.gz", escapeshellarg($source->getUrl())));
+            $downloadProcess->setTimeout(3600);
+            $downloadProcess->run();
+
+            $output->writeln(' <info>OK</info>');
+            if (!$downloadProcess->isSuccessful()) {
+                throw new \RuntimeException($downloadProcess->getErrorOutput());
+            }
+
+
+            $output->write('<comment>Extracting...</comment>');
+            $extractProcess = new Process(
+                sprintf(
+                    'tar xfz phpstorm.tar.gz; rm phpstorm.tar.gz; mv %1$s %2$s'
+                    , escapeshellarg($extractedFolder), escapeshellarg($targetFolder)
+                )
+            );
+            $extractProcess->run();
+            $output->writeln(' <info>OK</info>');
+            if (!$extractProcess->isSuccessful()) {
+                throw new \RuntimeException($extractProcess->getErrorOutput());
+            }
+
+        }
+
+        $output->write('<comment>Linking...</comment>');
+
+        $linkProcess = new Process(
+            sprintf(
+                'cd %2$s; ln -s -f %1$s PhpStorm', escapeshellarg($extractedFolder), escapeshellarg($targetFolder)
+            )
+        );
+        $linkProcess->run();
+        $output->writeln(' <info>OK</info>');
+        if (!$linkProcess->isSuccessful()) {
+            throw new \RuntimeException($linkProcess->getErrorOutput());
+        }
+
     }
 }

--- a/src/Repository/Eap.php
+++ b/src/Repository/Eap.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace CMuench\PHPStormDownloader\Repository;
+
+use Goutte\Client;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Class Eap
+ *
+ * @package CMuench\PHPStormDownloader\Repository
+ */
+class Eap extends Http
+{
+    protected $name = 'PhpStorm EAP';
+
+    private $url = 'https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Early+Access+Program';
+
+    private $pattern = '/PhpStorm-EAP-(\d+\.\d+)(?:-custom-jdk-linux)?\.tar\.gz/i';
+
+    /**
+     * @param OutputInterface $output
+     * @param Client $client
+     */
+    protected function fillSources(OutputInterface $output, Client $client)
+    {
+
+        $name = $this->name;
+        $url = $this->url;
+        $pattern = $this->pattern;
+
+        $crawler = $client->request('GET', $url);
+        $output->writeln('<info>OK</info>');
+        $crawler->filter('a.external-link')
+            ->each(function (Crawler $node) use ($pattern, $output, $name) {
+                $url = $node->attr('href');
+                $linkText = $node->text();
+                if (!preg_match($pattern, $linkText, $matches)) {
+                    return;
+                }
+
+                $phpStormVersion = $matches[1];
+                $output->writeln('<comment>Found ' . $name . ' Version: </comment><info>' . $phpStormVersion . '</info>');
+
+                $source = new HttpSource($name, $phpStormVersion, $url);
+                $this->sources[] = $source;
+            });
+    }
+}

--- a/src/Repository/Http.php
+++ b/src/Repository/Http.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace CMuench\PHPStormDownloader\Repository;
+
+use Goutte\Client;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class Http
+ *
+ * @package CMuench\PHPStormDownloader\Repository
+ */
+abstract class Http
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var array|HttpSource[]
+     */
+    protected $sources;
+
+    /**
+     * @param OutputInterface $output
+     */
+    final public function initialize(OutputInterface $output)
+    {
+        $output->write(sprintf('<comment>Request %s: </comment>', $this->name));
+
+        $this->sources = [];
+
+        $client = new Client();
+
+        $this->fillSources($output, $client);
+    }
+    
+    /**
+     * @param OutputInterface $output
+     * @param Client $client
+     */
+    abstract protected function fillSources(OutputInterface $output, Client $client);
+
+    /**
+     * @return array|HttpSource[]
+     */
+    public function getSources()
+    {
+        return $this->sources;
+    }
+
+}

--- a/src/Repository/HttpSource.php
+++ b/src/Repository/HttpSource.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: mot
+ * Date: 18.01.16
+ * Time: 19:54
+ */
+
+namespace CMuench\PHPStormDownloader\Repository;
+
+
+class HttpSource
+{
+    private $name;
+    private $version;
+    private $url;
+
+
+    /**
+     * HttpSource constructor.
+     *
+     * @param $name
+     * @param $version
+     * @param $url
+     */
+    public function __construct($name, $version, $url)
+    {
+        $this->name = $name;
+        $this->version = $version;
+        $this->url = $url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+}

--- a/src/Repository/Stable.php
+++ b/src/Repository/Stable.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace CMuench\PHPStormDownloader\Repository;
+use Goutte\Client;
+use Symfony\Component\BrowserKit\Response;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class Eap
+ *
+ * @package CMuench\PHPStormDownloader\Repository
+ */
+class Stable extends Http
+{
+    protected $name = 'PhpStorm stable';
+
+    protected $url = 'https://data.services.jetbrains.com/products/releases?code=PS&latest=true&type=release&_=999';
+
+    public function fillSources(OutputInterface $output, Client $client)
+    {
+        $url = $this->url;
+        $name = $this->name;
+
+        $client->request('GET', $url);
+
+        /** @var Response $response */
+        $response = $client->getResponse();
+
+        $data = json_decode($response->getContent(), true, 64);
+
+        if (!$data) {
+            return;
+        }
+
+        $version =  &$data['PS'][0]['build'];
+        $link = &$data['PS'][0]['downloads']['linux']['link'];
+
+        if (!strlen($version) || !strlen($link)) {
+            return;
+        }
+
+        $source = new HttpSource($name, $version, $link);
+        $this->sources[] = $source;
+    }
+}


### PR DESCRIPTION
this commit addresses the following issues and new options for the
"download" command:
- fix EAP version detection - the filename changed on server so that the
  pattern did not grep the link any longer. fix by updating the pattern.
- extract HTTP repository to obtain download links to Phpstorm .tar.gz
  packages and their versions (build). allows to add stable repository
  next to EAP repository.
- prevent download if build already exists. use --download to download
  even if it already exists. the release will be linked in any case.
- add stable repo. --stable makes the download command to use the stable
  Phpstorm version instead of the EAP.
